### PR TITLE
Fix cache publication errors without accepting incomplete entries

### DIFF
--- a/include/deep_jit/cache/disk.hpp
+++ b/include/deep_jit/cache/disk.hpp
@@ -48,12 +48,19 @@ public:
         fsync_dir(path);
 
         // Atomically rename the temporary directory to the final cache path
-        // NOTES: if another rank already created dir_path, rename will fail — that's fine
+        // A failed rename is only recoverable if a committed entry is visible.
         make_dirs(commit_path.parent_path());
         std::error_code error_code;
         std::filesystem::rename(path, commit_path, error_code);
         if (error_code) {
-            // Another rank beat us, then clean up our dir and use the existing one
+            // Check the marker with a separate error code to preserve the rename
+            // diagnostic, including when the destination cannot be inspected.
+            std::error_code marker_error;
+            if (not std::filesystem::exists(commit_path / kCommitFileName, marker_error) or marker_error)
+                throw std::filesystem::filesystem_error("failed to publish disk cache entry", path, commit_path, error_code);
+
+            // A committed destination is safe to reuse, even if a distributed
+            // filesystem reported an error after completing our own rename.
             // NOTES: avoid `std::filesystem::remove_all` here — it can segfault on
             // distributed filesystems, when concurrent processes operate
             // on the same parent directory, causing stale directory entries

--- a/tests/test_cuda_proj/main.cpp
+++ b/tests/test_cuda_proj/main.cpp
@@ -2977,6 +2977,39 @@ void test_ptxas_checks(const fs::path& cache_root) {
     unset_env("PTXAS_CHECK_JIT_NVCC_COMPILER");
 }
 
+void test_cache_publication_failure(const fs::path& cache_root) {
+    const auto publication_cache = cache_root / "publication_failure";
+    set_env("PUBLICATION_FAILURE_JIT_CACHE_DIR", publication_cache.string());
+    const auto runtime = make_runtime_with_prefix(
+        "PUBLICATION_FAILURE", get_test_cuda_project_dir() / "include_original");
+    unset_env("PUBLICATION_FAILURE_JIT_CACHE_DIR");
+    const auto source = get_template_source(73);
+    const auto artifact = publication_cache / "cache" /
+        std::format("publication_failure.{}", runtime->cache_key(source, runtime->default_compiler_options));
+    deep_jit::make_dirs(artifact);
+    deep_jit::write_file_sync(artifact / "partial", "incomplete");
+    bool failed = false;
+    try {
+        runtime->compile_without_load("publication_failure", source);
+    } catch (const fs::filesystem_error& error) {
+        failed = true;
+        DJ_HOST_ASSERT(error.code() == std::errc::directory_not_empty or error.code() == std::errc::file_exists);
+        DJ_HOST_ASSERT(error.path2() == artifact);
+    }
+    DJ_HOST_ASSERT(failed, "compilation reported success for an incomplete destination");
+    DJ_HOST_ASSERT(deep_jit::read(artifact / "partial") == "incomplete");
+    DJ_HOST_ASSERT(not fs::exists(artifact / deep_jit::kCommitFileName));
+    check_tmp_is_empty(publication_cache);
+
+    // Only the test owner removes its incomplete fixture before retrying.
+    DJ_HOST_ASSERT(fs::remove(artifact / "partial"));
+    DJ_HOST_ASSERT(fs::remove(artifact));
+    const auto kernel = runtime->compile("publication_failure", source);
+    DJ_HOST_ASSERT(launch_value(*runtime, kernel, 1) == 74);
+    DJ_HOST_ASSERT(fs::exists(artifact / deep_jit::kCommitFileName));
+    check_tmp_is_empty(publication_cache);
+}
+
 void test_compiler_failure_cleanup(Runtime& runtime, const fs::path& cache_root) {
     const std::string source = "extern \"C\" __global__ void invalid_cuda_source( {\n";
     const auto artifact = runtime.disk_cache.paths.front() / "cache" /
@@ -3314,6 +3347,7 @@ void run_tests(pybind11::module_ module) {
     run_test("kernel count", [&] { test_kernel_count(*runtime); });
     run_test("PTXAS checks", [&] { test_ptxas_checks(cache_root); });
     run_test("compiler failure cleanup", [&] { test_compiler_failure_cleanup(*runtime, cache_root); });
+    run_test("cache publication failure", [&] { test_cache_publication_failure(cache_root); });
     run_test("backend output validation", [&] { test_backend_output_validation(*runtime, cache_root); });
     run_test("dump artifacts and launch overhead", [&] { test_dump_and_launch_overhead(*runtime); });
     run_test("dump options on cache hit", [&] { test_dump_options_on_cache_hit(cache_root); });

--- a/tests/test_disk_cache.py
+++ b/tests/test_disk_cache.py
@@ -1,0 +1,33 @@
+"""CPU-only disk-cache publication regressions; run with python tests/test_disk_cache.py."""
+
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix='deep-jit-disk-cache-') as directory:
+        build = Path(directory)
+        executable = build / 'disk_cache_test'
+        subprocess.run([
+            *shlex.split(os.environ.get('CXX', 'c++')),
+            '-std=c++20', '-O2', '-Wall', '-Wextra',
+            '-I', str(ROOT / 'include'),
+            str(ROOT / 'tests/test_disk_cache_proj/main.cpp'),
+            '-o', str(executable), '-ldl', '-pthread',
+        ], check=True)
+        scenarios = ['normal', 'winner', 'incomplete', 'permission', 'marker_permission']
+        for scenario in scenarios:
+            if scenario in ('permission', 'marker_permission') and os.geteuid() == 0:
+                print(f'{scenario}: skipped (requires an unprivileged user)', flush=True)
+                continue
+            subprocess.run([str(executable), scenario, str(build / scenario)], check=True, timeout=30)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_disk_cache_proj/main.cpp
+++ b/tests/test_disk_cache_proj/main.cpp
@@ -1,0 +1,90 @@
+#include <deep_jit/cache/disk.hpp>
+
+#include <iostream>
+#include <stdexcept>
+
+namespace fs = std::filesystem;
+
+void require(bool condition, const char* message) {
+    if (not condition)
+        throw std::runtime_error(message);
+}
+
+void expect_failure(deep_jit::DiskCacheEntry& entry, std::errc expected) {
+    const auto temporary = entry.path;
+    try {
+        entry.commit();
+    } catch (const fs::filesystem_error& error) {
+        const bool nonempty_destination = expected == std::errc::directory_not_empty and
+                                          error.code() == std::errc::file_exists;
+        require(error.code() == expected or nonempty_destination, "original rename error was lost");
+        require(error.path1() == temporary and error.path2() == entry.commit_path,
+                "rename paths were lost");
+        require(not entry.hit and not entry.committed and entry.path == temporary,
+                "failed publication changed entry state");
+        require(deep_jit::read(temporary / "payload") == "new", "temporary payload was lost");
+        return;
+    }
+    throw std::runtime_error("commit returned success after failed publication");
+}
+
+int main(int argc, char** argv) {
+    try {
+        require(argc == 3, "expected scenario and cache root");
+        const std::string scenario = argv[1];
+        const fs::path root = argv[2];
+        deep_jit::DiskCache cache({root});
+        fs::path temporary;
+        {
+            auto entry = cache.entry("test", "digest");
+            require(not entry.hit, "expected initial miss");
+            temporary = entry.path;
+            deep_jit::write_file_sync(temporary / "payload", "new");
+            if (scenario == "incomplete") {
+                deep_jit::make_dirs(entry.commit_path);
+                deep_jit::write_file_sync(entry.commit_path / "partial", "old");
+                expect_failure(entry, std::errc::directory_not_empty);
+                expect_failure(entry, std::errc::directory_not_empty);
+                require(deep_jit::read(entry.commit_path / "partial") == "old", "destination changed");
+                require(not fs::exists(entry.commit_path / deep_jit::kCommitFileName), "destination marked committed");
+            } else if (scenario == "permission" or scenario == "marker_permission") {
+                const auto parent = entry.commit_path.parent_path();
+                deep_jit::make_dirs(parent);
+                const auto permissions = fs::status(parent).permissions();
+                fs::permissions(parent, scenario == "permission" ? fs::perms::owner_read | fs::perms::owner_exec
+                                                                  : fs::perms::owner_read);
+                try {
+                    expect_failure(entry, std::errc::permission_denied);
+                } catch (...) {
+                    fs::permissions(parent, permissions);
+                    throw;
+                }
+                fs::permissions(parent, permissions);
+                require(not fs::exists(entry.commit_path), "permission failure published an entry");
+                require(entry.commit() == entry.commit_path, "retry failed after restoring permissions");
+            } else if (scenario == "winner") {
+                // Both entries miss before either publishes, then the loser observes the winner.
+                auto winner = cache.entry("test", "digest");
+                deep_jit::write_file_sync(winner.path / "payload", "winner");
+                winner.commit();
+                require(entry.commit() == winner.path, "loser did not reuse winner");
+                require(deep_jit::read(entry.path / "payload") == "winner", "winner payload replaced");
+                require(entry.hit and entry.committed, "loser state not committed");
+                require(not fs::exists(temporary), "loser temporary leaked");
+            } else {
+                require(scenario == "normal", "unknown scenario");
+                require(entry.commit() == entry.commit_path, "wrong published path");
+                require(entry.commit() == entry.commit_path, "repeated commit failed");
+                require(entry.hit and entry.committed, "successful state not committed");
+                auto hit = cache.entry("test", "digest");
+                require(hit.hit and deep_jit::read(hit.path / "payload") == "new", "published entry not reusable");
+                require(hit.commit() == entry.path, "hit commit changed path");
+            }
+        }
+        require(not fs::exists(temporary), "temporary leaked after destruction");
+        std::cout << scenario << ": passed\n";
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
A failed cache-publication rename could discard a completed build and return an incomplete or nonexistent destination as a cache hit.

Check the destination's `.committed` marker before accepting the failed rename. If the marker is absent or cannot be inspected, throw `filesystem_error` with the original rename error and both paths. Keep the entry uncommitted so its temporary build remains available for retry and is cleaned up on destruction. Existing incomplete destinations are left untouched after a failed rename.

Adds CPU regressions for normal publication, an overlapping committed winner, incomplete destinations, permission failures, and retries. Adds a CUDA regression for a failed publication followed by successful compilation and kernel launch after the test removes its own incomplete fixture.

Validation:

- All 5 CPU scenarios pass. On the base revision, incomplete destinations, rename permission failures, and marker-inspection permission failures reproduce false success; normal publication and overlapping-winner controls pass.
- CUDA validation passes on an RTX 3060, including the new publication-failure regression and existing same-key and mixed-key eight-process publication tests. The local harness excludes the unsupported TMA test and its expected artifact; that harness adjustment is not part of this PR.
- A combined check with the symlink-cleanup fix preserves outside files when a failed publication destroys its temporary entry.
- Independent diff review reports no actionable findings.

Fixes #3.
