### PR TITLE
Make the libdw dependency of C++ backtraces optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ DeepJIT handles the JIT infrastructure so that kernel libraries can focus on the
 | **CUDA** | NVCC compiles CUDA source to CUBIN; the CUDA Driver API loads and launches kernels. | CUDA headers 12.4+, NVCC 12.9+, and PyTorch with CUDA support. |
 | **Ascend** | Bisheng and ld.lld compile and link Ascend kernel source; ACL loads and launches kernels. | CANN with `bin/bisheng`, `bin/ld.lld`, and the Ascend `adv_api` headers; ACL and `torch_npu` headers and runtime. |
 
-The host environment must provide Linux, a C++20 compiler and standard library with `std::format` support, Python, pybind11, and the dependencies for the selected backend. DeepJIT is intended to be embedded into your extension as a header-only dependency.
+The host environment must provide Linux, a C++20 compiler and standard library with `std::format` support, Python, pybind11, and the dependencies for the selected backend. Installing the elfutils development headers (`libdw-dev` on Debian/Ubuntu) additionally enables file and line information in C++ backtraces; without them backtraces keep function names only. DeepJIT is intended to be embedded into your extension as a header-only dependency.
 
 See [Integration](#integration) for setup, [CUDA](#cuda) for GPU usage, and [Ascend](#ascend) for NPU usage.
 

--- a/include/deep_jit/utils/exception.hpp
+++ b/include/deep_jit/utils/exception.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include <elfutils/libdwfl.h>
+#if defined(__has_include)
+#    if __has_include(<elfutils/libdwfl.h>)
+#        include <elfutils/libdwfl.h>
+#        define DJ_HAS_LIBDW 1
+#    endif
+#endif
 
 #include <array>
 #include <cstdint>
@@ -17,6 +22,8 @@
 namespace deep_jit::exception {
 
 namespace detail {
+
+#ifdef DJ_HAS_LIBDW
 
 struct DwflApi {
     struct FrameInfo {
@@ -95,6 +102,25 @@ struct DwflApi {
         return result;
     }
 };
+
+#else
+
+// `libdw` headers are unavailable at build time. Backtraces fall back to
+// `dladdr` only: they keep demangled function names but report "??:0" for the
+// file and line of each frame. Install the elfutils development headers to
+// restore them.
+struct DwflApi {
+    struct FrameInfo {
+        const char* function = nullptr;
+        std::string file_line = "??:0";
+    };
+
+    bool valid() const { return false; }
+    void refresh() const {}
+    FrameInfo find(const std::uintptr_t) const { return {}; }
+};
+
+#endif
 
 inline bool is_python_frame(const Dl_info& info) {
     if (info.dli_sname != nullptr) {


### PR DESCRIPTION
DeepJIT is header-only, and 17 of its 27 public headers transitively include `include/deep_jit/utils/exception.hpp`. That file unconditionally did `#include <elfutils/libdwfl.h>`, so on a machine that has the `libdw` runtime but not the elfutils development headers, **no** DeepJIT header compiles — including `tests/test_exception.py`, the only test that does not need a GPU. Stock Ubuntu 24.04 is exactly that case: `libdw1t64` is installed, `libdw-dev` is not, and the requirement is not mentioned anywhere in the README.

Reproduction with the same flags as `validate_header_self_containment` in `tests/test_cuda.py` (Ubuntu 24.04.4, g++ 14.4.0, no `libdw-dev`):

```
include/deep_jit/utils/exception.hpp:3:10: fatal error: elfutils/libdwfl.h: No such file or directory
    3 | #include <elfutils/libdwfl.h>
      |          ^~~~~~~~~~~~~~~~~~~~
```

Sweeping `include/deep_jit/**/*.hpp` (excluding `backend/ascend/`) the same way, 13 headers fail on that single line.

The library already treats `libdw` as optional at runtime — `DwflApi`'s constructor does `dlopen("libdw.so.1", RTLD_LAZY | RTLD_LOCAL)` and `valid()` gates every use of the loaded symbols. Only the header was an unconditional requirement.

This makes the include conditional on `__has_include` and supplies a no-op `DwflApi` when the headers are absent, so backtraces fall back to the existing `dladdr` path. The same sweep after the change:

```
PASS=17 FAIL=5
    0 failures on elfutils/libdwfl.h
    the remaining 5 are this machine lacking cusparse.h / Python.h, unrelated
```

Backtraces on a header-less machine keep demangled function names and the `file:line` in the panic message, and report `??:0` per frame. `tests/test_exception.py` needs no change — it still sees `panic_leaf`, `panic_middle`, `panic_entry` and `.cpp:` in the message. On a machine with `libdw-dev` the guarded branch is byte-identical to before, so nothing changes there; I could not build that variant locally because installing `libdw-dev` requires root.
