### PR TITLE
Migrate DeepJIT CUDA integration to the PyTorch stable ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,5 +17,9 @@ include_directories(
 link_directories(${TORCH_INSTALL_PREFIX}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs)
 
 pybind11_add_module(_C csrc/python_api.cpp)
+target_compile_definitions(_C PRIVATE
+    TORCH_TARGET_VERSION=0x020a000000000000
+    USE_CUDA
+)
 target_link_libraries(_C PRIVATE ${TORCH_LIBRARIES} torch_python)
 target_link_options(_C PRIVATE "-Wl,-Bsymbolic-functions")

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ DeepJIT handles the JIT infrastructure so that kernel libraries can focus on the
 | **CUDA** | NVCC compiles CUDA source to CUBIN; the CUDA Driver API loads and launches kernels. | CUDA headers 12.4+, NVCC 12.9+, and PyTorch with CUDA support. |
 | **Ascend** | Bisheng and ld.lld compile and link Ascend kernel source; ACL loads and launches kernels. | CANN with `bin/bisheng`, `bin/ld.lld`, and the Ascend `adv_api` headers; ACL and `torch_npu` headers and runtime. |
 
-The host environment must provide Linux, a C++20 compiler and standard library with `std::format` support, Python, pybind11, and the dependencies for the selected backend. DeepJIT is intended to be embedded into your extension as a header-only dependency.
+The host environment must provide Linux, a C++20 compiler and standard library with `std::format` support, Python, pybind11, and the dependencies for the selected backend. DeepJIT is intended to be embedded into your extension as a header-only dependency. CUDA consumers should compile with `TORCH_TARGET_VERSION=0x020a000000000000` and `USE_CUDA`; this targets PyTorch's stable ABI with PyTorch 2.10 as the minimum runtime version.
 
 See [Integration](#integration) for setup, [CUDA](#cuda) for GPU usage, and [Ascend](#ascend) for NPU usage.
 

--- a/include/deep_jit/backend/cuda/kernel.hpp
+++ b/include/deep_jit/backend/cuda/kernel.hpp
@@ -8,8 +8,10 @@
 #include <memory>
 #include <type_traits>
 
-#include <ATen/cuda/CUDAContext.h>
 #include <cuda.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/headeronly/util/shim_utils.h>
 
 #include <deep_jit/backend/cuda/driver.hpp>
 #include <deep_jit/backend/cuda/options.hpp>
@@ -161,9 +163,14 @@ public:
         config.blockDimY = launch_options.block_dim->y;
         config.blockDimZ = launch_options.block_dim->z;
         config.sharedMemBytes = *launch_options.num_smem_bytes;
+        void* current_stream = nullptr;
+        if (not launch_options.stream) {
+            const auto device_index = torch::stable::accelerator::getCurrentDeviceIndex();
+            TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_index, &current_stream));
+        }
         config.hStream = launch_options.stream
             ? *launch_options.stream
-            : at::cuda::getCurrentCUDAStream().stream();
+            : static_cast<CUstream>(current_stream);
         config.attrs = num_attributes == 0 ? nullptr : attributes.data();
         config.numAttrs = num_attributes;
         DJ_CUDA_DRIVER_CHECK(driver::lazy_cuLaunchKernelEx(

--- a/include/deep_jit/backend/cuda/kernel.hpp
+++ b/include/deep_jit/backend/cuda/kernel.hpp
@@ -31,6 +31,15 @@ inline void* kernel_arg_pointer(const T& value) {
     }
 }
 
+// Utility to get the current CUDA stream for a given device using stable APIs.
+// Returns a CUstream for use with the CUDA Driver API.
+inline CUstream get_current_cuda_stream(const int32_t device_index) {
+    void* stream_ptr = nullptr;
+    TORCH_ERROR_CODE_CHECK(
+        aoti_torch_get_current_cuda_stream(device_index, &stream_ptr));
+    return static_cast<CUstream>(stream_ptr);
+}
+
 // Immutable CUDA kernel handles with shared ownership. Driver resources are
 // unloaded when the last shared owner is destroyed.
 class Kernel {
@@ -163,14 +172,9 @@ public:
         config.blockDimY = launch_options.block_dim->y;
         config.blockDimZ = launch_options.block_dim->z;
         config.sharedMemBytes = *launch_options.num_smem_bytes;
-        void* current_stream = nullptr;
-        if (not launch_options.stream) {
-            const auto device_index = torch::stable::accelerator::getCurrentDeviceIndex();
-            TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_index, &current_stream));
-        }
         config.hStream = launch_options.stream
             ? *launch_options.stream
-            : static_cast<CUstream>(current_stream);
+            : get_current_cuda_stream(torch::stable::accelerator::getCurrentDeviceIndex());
         config.attrs = num_attributes == 0 ? nullptr : attributes.data();
         config.numAttrs = num_attributes;
         DJ_CUDA_DRIVER_CHECK(driver::lazy_cuLaunchKernelEx(

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -222,6 +222,7 @@ def validate_header_self_containment(temporary_dir):
         source_path.write_text(f'#include <{header.as_posix()}>\n', encoding='utf-8')
         command = [
             os.environ.get('CXX', 'c++'), '-std=c++20', '-fsyntax-only', '-Werror',
+            '-DTORCH_TARGET_VERSION=0x020a000000000000', '-DUSE_CUDA',
             '-Wno-attributes', '-Wno-deprecated-declarations',
             '-Wno-missing-field-initializers', '-Wno-psabi',
             str(source_path),
@@ -787,6 +788,7 @@ def run_worker():
             sources=[str(TEST_CUDA_PROJECT / 'main.cpp')],
             extra_cflags=[
                 '-std=c++20', '-O3', '-fPIC', '-Wall', '-Wextra', '-Werror',
+                '-DTORCH_TARGET_VERSION=0x020a000000000000', '-DUSE_CUDA',
                 '-Wno-attributes', '-Wno-missing-field-initializers',
                 '-Wno-psabi', '-Wno-deprecated-declarations',
             ],

--- a/tests/test_cuda_proj/main.cpp
+++ b/tests/test_cuda_proj/main.cpp
@@ -53,21 +53,38 @@ int python_api_num_initializations = 0;
 std::shared_ptr<Runtime> process_test_runtime;
 std::shared_ptr<Runtime> gil_test_runtime;
 
+cudaStream_t get_stream_from_pool(const int32_t device_index) {
+    void* stream = nullptr;
+    TORCH_ERROR_CODE_CHECK(
+        torch_get_cuda_stream_from_pool(false, device_index, &stream));
+    return static_cast<cudaStream_t>(stream);
+}
+
 class TorchCUDAStreamGuard {
 public:
-    TorchCUDAStreamGuard(cudaStream_t stream, const int device_index)
-        : device_index(device_index) {
-        TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_index, &previous_stream));
-        TORCH_ERROR_CODE_CHECK(torch_set_current_cuda_stream(stream, device_index));
+    TorchCUDAStreamGuard() = delete;
+
+    explicit TorchCUDAStreamGuard(cudaStream_t stream, int32_t device_index) {
+        TORCH_ERROR_CODE_CHECK(
+            aoti_torch_create_cuda_stream_guard(
+                static_cast<void*>(stream), device_index, &guard_));
     }
 
     ~TorchCUDAStreamGuard() {
-        (void)torch_set_current_cuda_stream(previous_stream, device_index);
+        if (guard_)
+            (void)aoti_torch_delete_cuda_stream_guard(guard_);
     }
 
+    // Match c10::cuda::CUDAStreamGuard: copying is disallowed because the
+    // guard has unique ownership, and moving is disallowed because an RAII
+    // stream guard has no uninitialized state to leave behind.
+    TorchCUDAStreamGuard(const TorchCUDAStreamGuard&) = delete;
+    TorchCUDAStreamGuard& operator=(const TorchCUDAStreamGuard&) = delete;
+    TorchCUDAStreamGuard(TorchCUDAStreamGuard&&) = delete;
+    TorchCUDAStreamGuard& operator=(TorchCUDAStreamGuard&&) = delete;
+
 private:
-    int device_index;
-    void* previous_stream = nullptr;
+    CUDAStreamGuardHandle guard_ = nullptr;
 };
 
 const fs::path& get_test_cuda_project_dir() {
@@ -1837,8 +1854,7 @@ void test_runtime_launch_features(Runtime& runtime) {
 
         runtime.default_launch_options.stream = std::nullopt;
         runtime.default_launch_options.enable_pdl = false;
-        cudaStream_t current_stream = nullptr;
-        DJ_CUDA_RUNTIME_CHECK(cudaStreamCreate(&current_stream));
+        const auto current_stream = get_stream_from_pool(device_index);
 
         cudaGraph_t graph = nullptr;
         cudaGraphExec_t graph_exec = nullptr;
@@ -1885,7 +1901,6 @@ void test_runtime_launch_features(Runtime& runtime) {
         DJ_CUDA_RUNTIME_CHECK(cudaGraphExecDestroy(graph_exec));
         DJ_CUDA_RUNTIME_CHECK(cudaGraphDestroy(graph));
 
-        DJ_CUDA_RUNTIME_CHECK(cudaStreamDestroy(current_stream));
         DJ_CUDA_RUNTIME_CHECK(cudaStreamDestroy(stream));
         stream = nullptr;
         DJ_CUDA_RUNTIME_CHECK(cudaFree(output));

--- a/tests/test_cuda_proj/main.cpp
+++ b/tests/test_cuda_proj/main.cpp
@@ -22,8 +22,9 @@
 #include <vector>
 
 #include <cuda_runtime.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <pybind11/pybind11.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/headeronly/util/shim_utils.h>
 #include <unistd.h>
 
 #include <deep_jit/backend/cuda/backend.hpp>
@@ -51,6 +52,23 @@ deep_jit::LazyInit<Runtime> python_api_jit(nullptr);
 int python_api_num_initializations = 0;
 std::shared_ptr<Runtime> process_test_runtime;
 std::shared_ptr<Runtime> gil_test_runtime;
+
+class TorchCUDAStreamGuard {
+public:
+    TorchCUDAStreamGuard(cudaStream_t stream, const int device_index)
+        : device_index(device_index) {
+        TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_index, &previous_stream));
+        TORCH_ERROR_CODE_CHECK(torch_set_current_cuda_stream(stream, device_index));
+    }
+
+    ~TorchCUDAStreamGuard() {
+        (void)torch_set_current_cuda_stream(previous_stream, device_index);
+    }
+
+private:
+    int device_index;
+    void* previous_stream = nullptr;
+};
 
 const fs::path& get_test_cuda_project_dir() {
     static const fs::path path = [] {
@@ -1819,13 +1837,14 @@ void test_runtime_launch_features(Runtime& runtime) {
 
         runtime.default_launch_options.stream = std::nullopt;
         runtime.default_launch_options.enable_pdl = false;
-        const auto current_stream = c10::cuda::getStreamFromPool();
+        cudaStream_t current_stream = nullptr;
+        DJ_CUDA_RUNTIME_CHECK(cudaStreamCreate(&current_stream));
 
         cudaGraph_t graph = nullptr;
         cudaGraphExec_t graph_exec = nullptr;
         {
-            const c10::cuda::CUDAStreamGuard stream_guard(current_stream);
-            DJ_CUDA_RUNTIME_CHECK(cudaStreamBeginCapture(current_stream.stream(), cudaStreamCaptureModeGlobal));
+            const TorchCUDAStreamGuard stream_guard(current_stream, device_index);
+            DJ_CUDA_RUNTIME_CHECK(cudaStreamBeginCapture(current_stream, cudaStreamCaptureModeGlobal));
             runtime.launch(
                 kernel, {
                     .num_smem_bytes = sizeof(int),
@@ -1833,12 +1852,12 @@ void test_runtime_launch_features(Runtime& runtime) {
                     .block_dim = dim3(32, 1, 1),
                 },
                 output, argument_storage, 10);
-            DJ_CUDA_RUNTIME_CHECK(cudaStreamEndCapture(current_stream.stream(), &graph));
+            DJ_CUDA_RUNTIME_CHECK(cudaStreamEndCapture(current_stream, &graph));
         }
         check_graph(graph);
         DJ_CUDA_RUNTIME_CHECK(cudaGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
-        DJ_CUDA_RUNTIME_CHECK(cudaGraphLaunch(graph_exec, current_stream.stream()));
-        DJ_CUDA_RUNTIME_CHECK(cudaStreamSynchronize(current_stream.stream()));
+        DJ_CUDA_RUNTIME_CHECK(cudaGraphLaunch(graph_exec, current_stream));
+        DJ_CUDA_RUNTIME_CHECK(cudaStreamSynchronize(current_stream));
         check_output(43, 44);
         DJ_CUDA_RUNTIME_CHECK(cudaGraphExecDestroy(graph_exec));
         DJ_CUDA_RUNTIME_CHECK(cudaGraphDestroy(graph));
@@ -1846,7 +1865,7 @@ void test_runtime_launch_features(Runtime& runtime) {
         graph = nullptr;
         graph_exec = nullptr;
         {
-            const c10::cuda::CUDAStreamGuard stream_guard(current_stream);
+            const TorchCUDAStreamGuard stream_guard(current_stream, device_index);
             DJ_CUDA_RUNTIME_CHECK(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
             runtime.launch(
                 kernel, {
@@ -1866,6 +1885,7 @@ void test_runtime_launch_features(Runtime& runtime) {
         DJ_CUDA_RUNTIME_CHECK(cudaGraphExecDestroy(graph_exec));
         DJ_CUDA_RUNTIME_CHECK(cudaGraphDestroy(graph));
 
+        DJ_CUDA_RUNTIME_CHECK(cudaStreamDestroy(current_stream));
         DJ_CUDA_RUNTIME_CHECK(cudaStreamDestroy(stream));
         stream = nullptr;
         DJ_CUDA_RUNTIME_CHECK(cudaFree(output));


### PR DESCRIPTION
## Summary

- Migrate CUDA stream APIs to the PyTorch 2.10 stable ABI
- Update build configuration, tests, and documentation

The Ascend build is unchanged.

Note: The CUDA extension uses PyTorch’s stable ABI, but it is not CPython ABI-stable because DeepJIT’s GIL helper still depends on pybind11 and CPython-specific APIs. Separate builds are required per Python version.

cc @janeyx99, @Harry-Chen

## Testing

- `python tests/test_cuda.py` : All DeepJIT tests passed

ran [torch-abi-audit](https://pypi.org/project/torch-abi-audit/) on minimal extension example (found here https://github.com/deepseek-ai/DeepJIT/commit/36a98fcc005eab1ab50d84fab636774c0992776c) and got   

```
[STABLE  ] [uses-private-api      ] _deep_jit_stable_abi_probe.cpython-312-x86_64-linux-gnu.so  (stable_shim=41, unstable=0)
        cpython violation: PyDict_SetDefault
        cpython violation: PyFrame_GetBack
        cpython violation: PyGILState_Check
        cpython violation: PyInstanceMethod_New
        cpython violation: PyInstanceMethod_Type
        cpython violation: _PyObject_GetDictPtr
        cpython violation: _PyThreadState_UncheckedGet
        cpython violation: _PyType_Lookup 
```
        
Most of these stable shims came in from included headers, but some came from `#include <deep_jit/backend/cuda/backend.hpp>`, and none of them were unstable. 

------------------------------------------------------------------------
## Bencmark
These benchmarks compare main against the stable-ABI branch on the SM90 DeepGEMM DeepJIT paths using the same workloads and report both `first call` and `warm call` timings. `First call` measures cold-start end-to-end latency, including JIT compilation, loading, and initial launch overhead in a fresh subprocess with a fresh JIT cache, while `warm call` measures steady-state per-launch GPU execution after warmup. For evaluating the specific deep_jit launch-path change, `warm call` is the more direct signal because it isolates runtime launch behavior from one-time compilation costs. The kernels and parameters shapes used for this benchmark are:

- `fp8_gemm_nt`:   `a shape (4096, 2048)`, `b shape (7168, 2048)`
- `grouped_fp8_nt`: `a shape (3712, 2048)`, `b shape (4, 4096, 2048)`, `grouped_layout shape (3712)`
- `tf32_hc_prenorm_gemm`: `a shape (4096, 7168)`, `b shape (24, 7168)`, `num_splits=16`
- `fp8_mqa_logits`: `seq=512` `kv=4096` `h=32` `d=128`

First Call
| Kernel | main (ms) | stable (ms) | diff (ms)
|---|---|---| --- |
| fp8_gemm_nt| 3747.508 | 3915.070 | +167.562 (4.47% slower)  
| grouped_fp8_nt | 5453.177 | 5519.743 | +66.566  (1.22% slower)
| tf32_hc_prenorm_gemm | 1610.871 | 1584.711 | -26.160 (1.62% faster) 
| fp8_mqa_logits | 1542.386 | 1482.790 | -59.596 (-3.86% faster)

Warm Calls (average over 500 calls)
| Kernel | main (μs) | stable (μs) | diff (μs)
|---|---|---| --- |
| fp8_gemm_nt| 177.9 | 177.3 | -0.6 (0.34% faster)  
| grouped_fp8_nt | 215.5 | 212.1 | -3.4  (1.58% faster)
| tf32_hc_prenorm_gemm | 62.2 | 62.3 | +0.1 (0.16% slower) 
| fp8_mqa_logits | 49.7 | 49.8 | +0.1 (0.2% slower)

Across the SM90 DeepJIT benchmark cases, the stable-ABI branch runtime is essentially the same as main.